### PR TITLE
add materials

### DIFF
--- a/src/handlers/products.rs
+++ b/src/handlers/products.rs
@@ -457,7 +457,6 @@ pub struct Product {
 
 #[get("")]
 pub async fn get_products(
-    _: AuthenticatedUser,
     pool: web::Data<PgPool>,
     query: web::Query<ProductQuery>,
 ) -> Result<HttpResponse, actix_web::Error> {
@@ -542,8 +541,20 @@ async fn get_colors() -> impl Responder {
             label: "Червоний".into(),
         },
         OptionValue {
+            value: "pink".into(),
+            label: "Рожевий".into(),
+        },
+        OptionValue {
             value: "blue".into(),
             label: "Синій".into(),
+        },
+        OptionValue {
+            value: "yellow".into(),
+            label: "Жовтий".into(),
+        },
+        OptionValue {
+            value: "grey".into(),
+            label: "Сірий".into(),
         },
         OptionValue {
             value: "black".into(),
@@ -552,6 +563,10 @@ async fn get_colors() -> impl Responder {
         OptionValue {
             value: "white".into(),
             label: "Білий".into(),
+        },
+        OptionValue {
+            value: "other".into(),
+            label: "Інший".into(),
         },
     ];
     HttpResponse::Ok().json(data)
@@ -696,35 +711,586 @@ async fn get_genders() -> impl Responder {
     let data = vec![
         OptionValue {
             value: "male".into(),
-            label: "Чоловіча".parse().unwrap(),
+            label: "Чоловіче".into(),
         },
         OptionValue {
             value: "female".into(),
-            label: "Жіноча".parse().unwrap(),
+            label: "Жіноче".into(),
+        },
+        OptionValue {
+            value: "kids".into(),
+            label: "Дитяче".into(),
         },
         OptionValue {
             value: "unisex".into(),
-            label: "Унісекс".parse().unwrap(),
+            label: "Унісекс".into(),
         },
     ];
     HttpResponse::Ok().json(data)
 }
 
+#[derive(Serialize)]
+pub struct ProductCharacteristics {
+    pub shoe_materials: Vec<OptionValue>,
+    pub clothing_materials: Vec<OptionValue>,
+    pub home_types: Vec<OptionValue>,
+    pub home_materials: Vec<OptionValue>,
+    pub book_genres: Vec<OptionValue>,
+    pub book_binding: Vec<OptionValue>,
+    pub book_languages: Vec<OptionValue>,
+    pub garden_types: Vec<OptionValue>,
+    pub electronics_types: Vec<OptionValue>,
+    pub auto_types: Vec<OptionValue>,
+    pub stationery_types: Vec<OptionValue>,
+    pub activity_types: Vec<OptionValue>,
+    pub tourism_types: Vec<OptionValue>,
+    pub water_sports_types: Vec<OptionValue>,
+    pub cycling_types: Vec<OptionValue>,
+    pub climbing_types: Vec<OptionValue>,
+    pub picnic_types: Vec<OptionValue>,
+    pub children_types: Vec<OptionValue>,
+}
+
 #[get("/options/materials")]
 async fn get_materials() -> impl Responder {
-    let data = vec![
-        OptionValue {
-            value: "leather".into(),
-            label: "Шкіра".parse().unwrap(),
-        },
-        OptionValue {
-            value: "cotton".into(),
-            label: "Бавовна".parse().unwrap(),
-        },
-        OptionValue {
-            value: "polyester".into(),
-            label: "Поліестер".parse().unwrap(),
-        },
-    ];
+    let data = ProductCharacteristics {
+        shoe_materials: vec![
+            OptionValue {
+                value: "suede".into(),
+                label: "Замша".into(),
+            },
+            OptionValue {
+                value: "nubuck".into(),
+                label: "Нубук".into(),
+            },
+            OptionValue {
+                value: "mesh".into(),
+                label: "Сітка".into(),
+            },
+            OptionValue {
+                value: "other_shoes".into(),
+                label: "Інший".into(),
+            },
+        ],
+        clothing_materials: vec![
+            OptionValue {
+                value: "cotton".into(),
+                label: "Бавовна".into(),
+            },
+            OptionValue {
+                value: "wool".into(),
+                label: "Вовна".into(),
+            },
+            OptionValue {
+                value: "linen".into(),
+                label: "Льон".into(),
+            },
+            OptionValue {
+                value: "silk".into(),
+                label: "Шовк".into(),
+            },
+            OptionValue {
+                value: "polyester".into(),
+                label: "Поліестер".into(),
+            },
+            OptionValue {
+                value: "nylon".into(),
+                label: "Нейлон".into(),
+            },
+            OptionValue {
+                value: "acrylic".into(),
+                label: "Акрил".into(),
+            },
+            OptionValue {
+                value: "viscose".into(),
+                label: "Віскоза".into(),
+            },
+            OptionValue {
+                value: "denim".into(),
+                label: "Джинс".into(),
+            },
+            OptionValue {
+                value: "other_clothes".into(),
+                label: "Інший".into(),
+            },
+        ],
+        home_types: vec![
+            OptionValue {
+                value: "dishes".into(),
+                label: "Посуд".into(),
+            },
+            OptionValue {
+                value: "textile".into(),
+                label: "Текстиль".into(),
+            },
+            OptionValue {
+                value: "furniture".into(),
+                label: "Меблі".into(),
+            },
+            OptionValue {
+                value: "decor".into(),
+                label: "Декор".into(),
+            },
+            OptionValue {
+                value: "lighting".into(),
+                label: "Освітлення".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        home_materials: vec![
+            OptionValue {
+                value: "wood".into(),
+                label: "Дерево".into(),
+            },
+            OptionValue {
+                value: "glass".into(),
+                label: "Скло".into(),
+            },
+            OptionValue {
+                value: "ceramic".into(),
+                label: "Кераміка".into(),
+            },
+            OptionValue {
+                value: "metal".into(),
+                label: "Метал".into(),
+            },
+            OptionValue {
+                value: "fabric".into(),
+                label: "Тканина".into(),
+            },
+            OptionValue {
+                value: "plastic".into(),
+                label: "Пластик".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інше".into(),
+            },
+        ],
+        book_genres: vec![
+            OptionValue {
+                value: "fiction".into(),
+                label: "Художня література".into(),
+            },
+            OptionValue {
+                value: "non_fiction".into(),
+                label: "Нехудожня література".into(),
+            },
+            OptionValue {
+                value: "children".into(),
+                label: "Дитяча література".into(),
+            },
+            OptionValue {
+                value: "self_development".into(),
+                label: "Саморозвиток".into(),
+            },
+            OptionValue {
+                value: "business".into(),
+                label: "Бізнес".into(),
+            },
+            OptionValue {
+                value: "history".into(),
+                label: "Історія".into(),
+            },
+            OptionValue {
+                value: "fantasy".into(),
+                label: "Фантастика".into(),
+            },
+            OptionValue {
+                value: "detective".into(),
+                label: "Детектив".into(),
+            },
+            OptionValue {
+                value: "comics".into(),
+                label: "Комікс".into(),
+            },
+            OptionValue {
+                value: "novel".into(),
+                label: "Роман".into(),
+            },
+        ],
+        book_binding: vec![
+            OptionValue {
+                value: "soft".into(),
+                label: "М'яка".into(),
+            },
+            OptionValue {
+                value: "hard".into(),
+                label: "Тверда".into(),
+            },
+        ],
+        book_languages: vec![
+            OptionValue {
+                value: "ukrainian".into(),
+                label: "Українська".into(),
+            },
+            OptionValue {
+                value: "english".into(),
+                label: "Англійська".into(),
+            },
+            OptionValue {
+                value: "german".into(),
+                label: "Німецька".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інше".into(),
+            },
+        ],
+        garden_types: vec![
+            OptionValue {
+                value: "tools".into(),
+                label: "Інвентар (лопата, граблі, сапка, лійка, секатор)".into(),
+            },
+            OptionValue {
+                value: "equipment".into(),
+                label: "Техніка (газонокосарка, оприскувач)".into(),
+            },
+            OptionValue {
+                value: "seeds".into(),
+                label: "Насіння (овочі, квіти, фрукти)".into(),
+            },
+            OptionValue {
+                value: "fertilizers".into(),
+                label: "Добрива (проти шкідників, для росту)".into(),
+            },
+            OptionValue {
+                value: "containers".into(),
+                label: "Ємності (горщик, кашпо, контейнер для розсади, ящик, каністра, відро)".into(),
+            },
+            OptionValue {
+                value: "furniture".into(),
+                label: "Меблі для саду (стільці, лавки, дивани, столи, набори)".into(),
+            },
+            OptionValue {
+                value: "decor".into(),
+                label: "Декор (статуетки, фонтани, камені, плитка)".into(),
+            },
+            OptionValue {
+                value: "lighting".into(),
+                label: "Освітлення (сонячна лампа, ліхтар, гірлянда)".into(),
+            },
+            OptionValue {
+                value: "fencing".into(),
+                label: "Огорожі (пластикові, дерев'яні, металічні)".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        electronics_types: vec![
+            OptionValue {
+                value: "phone".into(),
+                label: "Телефон".into(),
+            },
+            OptionValue {
+                value: "laptop".into(),
+                label: "Ноутбук".into(),
+            },
+            OptionValue {
+                value: "tablet".into(),
+                label: "Планшет".into(),
+            },
+            OptionValue {
+                value: "headphones".into(),
+                label: "Навушники".into(),
+            },
+            OptionValue {
+                value: "watch".into(),
+                label: "Годинник".into(),
+            },
+            OptionValue {
+                value: "camera".into(),
+                label: "Фотоапарат".into(),
+            },
+            OptionValue {
+                value: "tv".into(),
+                label: "Телевізор".into(),
+            },
+            OptionValue {
+                value: "fridge".into(),
+                label: "Холодильник".into(),
+            },
+            OptionValue {
+                value: "dishwasher".into(),
+                label: "Посудомийка".into(),
+            },
+            OptionValue {
+                value: "game_console".into(),
+                label: "Приставка".into(),
+            },
+            OptionValue {
+                value: "washing_machine".into(),
+                label: "Пральна машина".into(),
+            },
+            OptionValue {
+                value: "speakers".into(),
+                label: "Колонки".into(),
+            },
+            OptionValue {
+                value: "sewing_machine".into(),
+                label: "Швейна машинка".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        auto_types: vec![
+            OptionValue {
+                value: "accessories".into(),
+                label: "Аксесуари".into(),
+            },
+            OptionValue {
+                value: "parts".into(),
+                label: "Запчастини".into(),
+            },
+            OptionValue {
+                value: "electronics".into(),
+                label: "Автоелектроніка".into(),
+            },
+            OptionValue {
+                value: "fluids".into(),
+                label: "Масло та рідини".into(),
+            },
+            OptionValue {
+                value: "care".into(),
+                label: "Догляд".into(),
+            },
+            OptionValue {
+                value: "tires".into(),
+                label: "Шини".into(),
+            },
+            OptionValue {
+                value: "rims".into(),
+                label: "Диски".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        stationery_types: vec![
+            OptionValue {
+                value: "writing".into(),
+                label: "Пишучі прилади (гелеві ручки, кулькові ручки, механічні олівці, графітні олівці, кольорові олівці, маркери)".into(),
+            },
+            OptionValue {
+                value: "paper".into(),
+                label: "Паперова продукція (зошит в клітинку, зошит в лінійку, щоденник, блокнот, калька, стікери для нотаток, папір для друку, картон/ватман)".into(),
+            },
+            OptionValue {
+                value: "organization".into(),
+                label: "Організація документів (папки, файли, розділювачі, обкладинки, підставки для ручок, органайзери)".into(),
+            },
+            OptionValue {
+                value: "office".into(),
+                label: "Офісне приладдя (степлер, скоби, скрепки, кнопки, клей-олівець, ножиці, лінійка, калькулятор)".into(),
+            },
+            OptionValue {
+                value: "art".into(),
+                label: "Творчість (альбом для малювання, фарби, художні кисті, фломастери, пластилін, крейда, наліпки, клей)".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        activity_types: vec![
+            OptionValue {
+                value: "tourism".into(),
+                label: "Туризм та походи".into(),
+            },
+            OptionValue {
+                value: "water_sports".into(),
+                label: "Водні види спорту".into(),
+            },
+            OptionValue {
+                value: "cycling".into(),
+                label: "Велоспорт".into(),
+            },
+            OptionValue {
+                value: "climbing".into(),
+                label: "Альпінізм".into(),
+            },
+            OptionValue {
+                value: "picnic".into(),
+                label: "Пікнік".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        tourism_types: vec![
+            OptionValue {
+                value: "tent".into(),
+                label: "Намет".into(),
+            },
+            OptionValue {
+                value: "sleeping_bag".into(),
+                label: "Спальний мішок".into(),
+            },
+            OptionValue {
+                value: "burner".into(),
+                label: "Пальник".into(),
+            },
+            OptionValue {
+                value: "backpack".into(),
+                label: "Рюкзак".into(),
+            },
+            OptionValue {
+                value: "sleeping_pad".into(),
+                label: "Каремат".into(),
+            },
+            OptionValue {
+                value: "dishes".into(),
+                label: "Посуд".into(),
+            },
+            OptionValue {
+                value: "compass".into(),
+                label: "Компас".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        water_sports_types: vec![
+            OptionValue {
+                value: "goggles".into(),
+                label: "Водні окуляри та маски".into(),
+            },
+            OptionValue {
+                value: "fins".into(),
+                label: "Ласти".into(),
+            },
+            OptionValue {
+                value: "boards".into(),
+                label: "Дошки".into(),
+            },
+            OptionValue {
+                value: "paddles".into(),
+                label: "Весла".into(),
+            },
+            OptionValue {
+                value: "life_jackets".into(),
+                label: "Рятувальні жилети".into(),
+            },
+            OptionValue {
+                value: "kayaks".into(),
+                label: "Байдарки".into(),
+            },
+            OptionValue {
+                value: "pump".into(),
+                label: "Насос".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        cycling_types: vec![
+            OptionValue {
+                value: "bicycle".into(),
+                label: "Велосипед".into(),
+            },
+            OptionValue {
+                value: "wheels".into(),
+                label: "Колеса".into(),
+            },
+            OptionValue {
+                value: "pump".into(),
+                label: "Насос".into(),
+            },
+            OptionValue {
+                value: "helmet".into(),
+                label: "Шолом".into(),
+            },
+            OptionValue {
+                value: "lights".into(),
+                label: "Ліхтарі".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        climbing_types: vec![
+            OptionValue {
+                value: "climbing_shoes".into(),
+                label: "Скельники".into(),
+            },
+            OptionValue {
+                value: "protection".into(),
+                label: "Страхування".into(),
+            },
+            OptionValue {
+                value: "carabiner".into(),
+                label: "Карабін".into(),
+            },
+            OptionValue {
+                value: "rope".into(),
+                label: "Мотузка".into(),
+            },
+            OptionValue {
+                value: "helmet".into(),
+                label: "Каска".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        picnic_types: vec![
+            OptionValue {
+                value: "plaid".into(),
+                label: "Плед".into(),
+            },
+            OptionValue {
+                value: "dishes".into(),
+                label: "Посуд".into(),
+            },
+            OptionValue {
+                value: "burner".into(),
+                label: "Пальник".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+        children_types: vec![
+            OptionValue {
+                value: "clothes".into(),
+                label: "Одяг (комбінезон, футболки, штани, боді, піжама)".into(),
+            },
+            OptionValue {
+                value: "shoes".into(),
+                label: "Взуття (повсякденне, зимове, гумові чоботи, інше)".into(),
+            },
+            OptionValue {
+                value: "toys".into(),
+                label: "Іграшки (м'які, розвиваючі, конструктори, для вулиці, інтерактивні, інші)".into(),
+            },
+            OptionValue {
+                value: "care".into(),
+                label: "Догляд (підгузки, ванночки, термометри, шампуні, щітки, інші)".into(),
+            },
+            OptionValue {
+                value: "education".into(),
+                label: "Навчання та творчість (розмальовка, для ліплення, пазли, навчальні зошити, абетка, цифри, інше)".into(),
+            },
+            OptionValue {
+                value: "other".into(),
+                label: "Інший".into(),
+            },
+        ],
+    };
+
     HttpResponse::Ok().json(data)
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a structured materials options endpoint and refine existing product handlers

New Features:
- Add /options/materials endpoint returning a comprehensive set of ProductCharacteristics with categorized material and type options

Enhancements:
- Expand color options with pink, yellow, grey, and other
- Refine gender option labels and add a kids category
- Remove unused AuthenticatedUser parameter from get_products handler
- Standardize label assignments to use Into instead of Parse for option values