### PR TITLE
fix(main): fixed openapi serving, added Scalar frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,60 +792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,7 +1904,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2427,7 +2372,6 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-types",
- "axum",
  "bigdecimal",
  "chrono",
  "dotenv",
@@ -2446,15 +2390,11 @@ dependencies = [
  "sqlx",
  "tokio",
  "utoipa",
+ "utoipa-actix-web",
+ "utoipa-scalar",
  "utoipa-swagger-ui",
  "uuid",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3389,16 +3329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,7 +3963,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4179,6 +4108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "utoipa-actix-web"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7eda9c23c05af0fb812f6a177514047331dac4851a2c8e9c4b895d6d826967f"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "utoipa",
+]
+
+[[package]]
 name = "utoipa-gen"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,6 +4128,18 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "actix-web",
+ "serde",
+ "serde_json",
+ "utoipa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,31 +4,45 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }
+futures = "0.3.31"
+futures-util = "0.3.31"
+
 actix-web = "4.10.2"
+actix-cors = "0.7"
+actix-multipart = "0.7.2"
+
+utoipa = { version = "5.3.1", features = ["macros", "actix_extras", "chrono"] }
+utoipa-actix-web = "0.1.2"
+utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
+utoipa-scalar = { version = "0.3.0", features = ["actix-web"] }
+
 serde = { version = "1.0.219", features = ["derive"] }
-chrono = { version = "0.4.40", features = ["serde"] }
 serde_json = "1.0"
-jsonwebtoken = "9"
-sqlx = { version = "0.8.5", features = ["postgres", "macros", "runtime-tokio", "tls-rustls", "uuid", "chrono", "bigdecimal"] }
+
+aws-types = "1.1"
+aws-sdk-s3 = "1.82.0"
+aws-config = "1.6.1"
+
+sqlx = { version = "0.8.5", features = [
+    "postgres",
+    "macros",
+    "runtime-tokio",
+    "tls-rustls",
+    "uuid",
+    "chrono",
+    "bigdecimal",
+] }
 rand_core = "0.9.3"
 argon2 = "0.5"
 dotenv = "0.15"
-tokio = { version = "1", features = ["full"] }
-lettre = { version = "0.11.15"}
-uuid = { version = "1", features = ["serde", "v4"] }
-futures-util = "0.3.31"
-utoipa = { version = "5.3.1", features = ["macros", "actix_extras"] }
-utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
-actix-cors = "0.7"
-actix-multipart = "0.7.2"
+chrono = { version = "0.4.40", features = ["serde"] }
+jsonwebtoken = "9"
+lettre = { version = "0.11.15" }
 sanitize-filename = "0.6.0"
-aws-sdk-s3 = "1.82.0"
-aws-config = "1.6.1"
 once_cell = "1.19"
-aws-types = "1.1"
 regex = "1"
+uuid = { version = "1", features = ["serde", "v4"] }
 reqwest = { version = "0.12.15", features = ["json", "multipart"] }
 mime_guess = "2.0"
 bigdecimal = { version = "0.4.8", features = ["serde"] }
-futures = "0.3.31"
-axum = "0.8.4"


### PR DESCRIPTION
## Summary by Sourcery

Integrate automatic OpenAPI spec generation and interactive UIs (Swagger and Scalar), refactor endpoint organization into modules, and update project dependencies

New Features:
- Serve OpenAPI documentation and Swagger UI via utoipa under `/api-docs/openapi.json`
- Add a Scalar frontend endpoint at `/scalar` for API schema interaction
- Modularize endpoint handlers into `auth`, `users`, and `products` modules

Bug Fixes:
- Fix OpenAPI serving pipeline integration in the main server

Enhancements:
- Refactor Actix application setup to use `into_utoipa_app`, `openapi_scope`, and `openapi_service`
- Rename and restructure service registrations under respective modules

Build:
- Update and consolidate Cargo.toml dependencies, adding AWS SDK crates, utoipa crates, and utility libraries